### PR TITLE
Add scripts for initramfs-tools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ clean:
 	rm $(NAME)
 
 $(NAME): upd72020x-load.c
-	gcc -o $@ $^
+	gcc -static -o $@ $^

--- a/upd72020x
+++ b/upd72020x
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Prepare hook script for initramfs-tools.
+# Modified by 2019-06-08 K.Ohta <whatisthis.sowhat _at_ gmail.com>
+#
+# This is hook script to make uploading firmware of Renesas uPD72020x
+# before loading module "xhci_pci".
+# This firmware *MUST BE* loaded before module loading.
+# Place this file to /etc/initramfs-tools/hooks.d ,
+# place upd72020x-load to /sbin ,
+# place firmware to /lib/firmware/renesas/ and
+# place upc72020x-check-and-init to /lib/initramfs-tools/scripts/init-top .
+# Hint:
+# To get firmware, you should fireware-updator (not driver) from anywhere
+# and extract using wine .(help will show run with /? arg).
+# Then, rename foo.mem to K2026.mem (and copy to /lib/firmware/renesas/).
+
+PREREQ=""
+
+prereqs()
+{
+	echo "$PREREQ"
+}
+
+UPD72020X_FW=/lib/firmware/renesas/K2026.mem
+UPD72020X_FW_CMD=/sbin/upd72020x-load
+UPD72020X_FW_SCRIPT=/sbin/upd72020x-check-and-init
+
+case $1 in
+prereqs)
+	prereqs
+	exit 0
+	;;
+esac
+
+if [ ! -e $UPD72020X_FW ]; then
+	exit 0
+fi
+if [ ! -x $UPD72020X_FW_CMD ]; then
+	exit 0
+fi
+if [ ! -x $UPD72020X_FW_SCRIPT ]; then
+	exit 0
+fi
+
+. /usr/share/initramfs-tools/scripts/functions
+. /usr/share/initramfs-tools/hook-functions
+
+copy_exec $UPD72020X_FW_CMD
+
+

--- a/upd72020x
+++ b/upd72020x
@@ -38,9 +38,6 @@ fi
 if [ ! -x $UPD72020X_FW_CMD ]; then
 	exit 0
 fi
-if [ ! -x $UPD72020X_FW_SCRIPT ]; then
-	exit 0
-fi
 
 . /usr/share/initramfs-tools/scripts/functions
 . /usr/share/initramfs-tools/hook-functions

--- a/upd72020x
+++ b/upd72020x
@@ -20,10 +20,10 @@ prereqs()
 {
 	echo "$PREREQ"
 }
-
-UPD72020X_FW=/lib/firmware/renesas/K2026.mem
-UPD72020X_FW_CMD=/sbin/upd72020x-load
-UPD72020X_FW_SCRIPT=/sbin/upd72020x-check-and-init
+UPD72020X_FW_DIR=/lib/firmware/renesas/
+UPD72020X_FW=${UPD72020X_FW_DIR}/K2026.mem
+UPD72020X_FW_CMD=/usr/sbin/upd72020x-load
+UPD72020X_FW_SCRIPT=/etc/initramfs-tools/scripts/init-top/upd72020x-check-and-init
 
 case $1 in
 prereqs)
@@ -32,16 +32,25 @@ prereqs)
 	;;
 esac
 
+. /usr/share/initramfs-tools/scripts/functions
+. /usr/share/initramfs-tools/hook-functions
+
 if [ ! -e $UPD72020X_FW ]; then
-	exit 0
+    verbose "no uPD72020x firmware to install"
+    exit 0
 fi
 if [ ! -x $UPD72020X_FW_CMD ]; then
 	exit 0
 fi
+#if [ ! -x $UPD72020X_FW_SCRIPT ]; then
+#	exit 0
+#fi
+if [ ! -d "${UPD72020X_FW_DIR}" ] ; then
+    verbose "no uPD72020x firmware to install"
+    exit 0
+fi
 
-. /usr/share/initramfs-tools/scripts/functions
-. /usr/share/initramfs-tools/hook-functions
-
+copy_file firmware $UPD72020X_FW
 copy_exec $UPD72020X_FW_CMD
 
 

--- a/upd72020x-check-and-init
+++ b/upd72020x-check-and-init
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Modified by 20190608 K.Ohta <whatisthis.sowhat _at_ gmail.com>
+# Place this script to /etc/initramfs-tools/scripts/init-top .
+# See upd72020x for details.
+
+dir=$(dirname $(readlink -f "$0"))
+
+cd "$dir"
+
+UPD72020X_FWNAME=/lib/modules/renesas/K2026.mem
+UPD72020X_CMD=/sbin/upd72020x-load
+
+lspci -m | grep uPD720202 | while read device trailer; do
+	if ! dmesg | grep "0000:$device" | tail -n 1 | grep -e "-110" > /dev/null; then
+		continue # not affected, device got up normally
+	fi
+
+	bus=$( echo "$device" | cut -d : -f 1)
+	dev=$( echo "$device" | cut -d : -f 2 | cut -d . -f 1)
+	fun=$( echo "$device" | cut -d : -f 2 | cut -d . -f 2)
+
+	# place loader to /sbin and firmware to /lib/firmware/renesas
+	$UPD72020X_CMD -u -b 0x$bus -d 0x$dev -f 0x$fun -i $UPD72020X_FWNAME
+
+	sleep 2
+
+	echo 1 > "/sys/bus/pci/devices/0000:$device/remove"
+done
+
+sleep 1
+
+echo 1 > /sys/bus/pci/rescan
+
+exit 0
+

--- a/upd72020x-check-and-init
+++ b/upd72020x-check-and-init
@@ -1,14 +1,15 @@
 #!/bin/bash
 # Modified by 20190608 K.Ohta <whatisthis.sowhat _at_ gmail.com>
 # Place this script to /etc/initramfs-tools/scripts/init-top .
+# Or, place to /usr/sbin (for booting with systemd)
 # See upd72020x for details.
 
 dir=$(dirname $(readlink -f "$0"))
 
 cd "$dir"
 
-UPD72020X_FWNAME=/lib/modules/renesas/K2026.mem
-UPD72020X_CMD=/sbin/upd72020x-load
+UPD72020X_FWNAME=/lib/firmware/renesas/K2026.mem
+UPD72020X_CMD=/usr/sbin/upd72020x-load
 
 lspci -m | grep uPD720202 | while read device trailer; do
 	if ! dmesg | grep "0000:$device" | tail -n 1 | grep -e "-110" > /dev/null; then

--- a/upd72020x-fwload.service
+++ b/upd72020x-fwload.service
@@ -1,0 +1,33 @@
+# Copyright (C) 2013 Colin Watson.
+#
+# This file is part of binfmt-support.
+#
+# binfmt-support is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# binfmt-support is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with binfmt-support; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+[Unit]
+Description=Load firmware for Renesas uPD72020x USB3 host.
+#Documentation=man:update-binfmts(8)
+DefaultDependencies=false
+After=local-fs.target 
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/upd72020x-check-and-init
+#ExecStop=/usr/sbin/update-binfmts --disable
+Restart=no
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These are scripts for initramfs-tools.
Booting with initrams, this loader *must* run before loading module xchi_pci, because most of motherboards already have another xhci (aka USB3.x) host chip, they needs xhci_pci.
So, initramfs *must* include this loader and script and firmware.
These scripte will effect re-run update-initramfs command to make new initramfs.

Regards,
Ohta.

Hook script is "upd72020x", place /etc/initramfs/hooks.d.
Firmware update script "upd72020x-check-and-init" must place to /etc/initramfs/scripts/init-top.
Executable must place to /sbin, and firmware must place to /lib/firmware/renesas .