### PR TITLE
Build fixes / improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 NAME=upd72020x-load
+CC ?= gcc
 
 .PHONY: all clean
 
@@ -8,4 +9,4 @@ clean:
 	rm $(NAME)
 
 $(NAME): upd72020x-load.c
-	gcc -o $@ $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^

--- a/upd72020x-load.c
+++ b/upd72020x-load.c
@@ -230,7 +230,7 @@ int read_eeprom(int fd, char *filename, unsigned int len) {
     int ofile;
     u_int ix, data01, jx, val32, status;
 
-    ofile = open(filename, O_CREAT | O_RDWR | O_TRUNC);
+    ofile = open(filename, O_CREAT | O_RDWR | O_TRUNC, 0644);
 
     RETURN_ON_ERR(ofile < 0, "ERROR: cant open file %s\n", filename);
 


### PR DESCRIPTION
First patch makes Makefile respect the CC, CFLAGS and LDFLAGS variables.

Second patch is a result of compiling the software with `-O2` in CFLAGS:

```
In file included from /usr/include/fcntl.h:328, from upd72020x-load.c:4:                                       
In function ‘open’, inlined from ‘read_eeprom’ at upd72020x-load.c:233:13:
/usr/include/bits/fcntl2.h:50:4: error: call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
   50 |    __open_missing_mode ();
      |    ^~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:11: upd72020x-load] Error 1
```