### PR TITLE
Add logging to upd72020x-check-and-init

### DIFF
--- a/upd72020x-check-and-init
+++ b/upd72020x-check-and-init
@@ -26,7 +26,9 @@ fi
 
 
 lspci -m | egrep "uPD720201|uPD720202" | while read device trailer; do
+	echo "Found possible uPD72020x on $device"
 	if ! dmesg | grep "0000:$device" | tail -n 1 | grep -e "-110" > /dev/null; then
+	        echo "May already be programmed, skipping."
 		continue # not affected, device got up normally
 	fi
 
@@ -40,6 +42,7 @@ lspci -m | egrep "uPD720201|uPD720202" | while read device trailer; do
 	fun=$( echo "$device" | cut -d : -f 2 | cut -d . -f 2)
 
 	# upload to RAM only, do not write EEPROM
+	echo "Uploading firmware to $device"
 	"$UPD72020X_CMD" -u -b 0x$bus -d 0x$dev -f 0x$fun -i "$UPD72020X_FW"
 
 	# revert change
@@ -50,11 +53,14 @@ lspci -m | egrep "uPD720201|uPD720202" | while read device trailer; do
 	sleep 2
 
 	echo 1 > "/sys/bus/pci/devices/0000:$device/remove"
+	echo "Done with $device"
 done
 
 sleep 1
 
 echo 1 > /sys/bus/pci/rescan
+
+echo "Done with all devices"
 
 exit 0
 


### PR DESCRIPTION
Add logging messages to show what upd72020x-check-and-init is doing. This is especially useful for the systemd unit.

Example of messages:
```
Feb 25 21:13:31 cm4-2devA systemd[1]: Starting Load firmware for Renesas uPD72020x USB3.0 host....
Feb 25 21:13:31 cm4-2devA upd72020x-check-and-init[3246]: Found possible uPD72020x on 01:00.0
Feb 25 21:13:31 cm4-2devA upd72020x-check-and-init[3246]: May already be programmed, skipping.
Feb 25 21:13:38 cm4-2devA upd72020x-check-and-init[3241]: Done with all devices
Feb 25 21:13:38 cm4-2devA systemd[1]: Finished Load firmware for Renesas uPD72020x USB3.0 host..
```