### PR TITLE
Use O_RDONLY over O_RDWR where possible to work on read-only filesystem

### DIFF
--- a/upd72020x-load.c
+++ b/upd72020x-load.c
@@ -431,7 +431,7 @@ int write_eeprom(int fd, char *filename, unsigned int len) {
 
     int ifile;
 
-    ifile = open(filename, O_RDWR);
+    ifile = open(filename, O_RDONLY);
     RETURN_ON_ERR(ifile < 0, "ERROR: cant open file image %s\n", filename);
 
     printf("STATUS: enabling EEPROM write\n");
@@ -475,7 +475,7 @@ int write_firmware(int fd, char *filename, unsigned int len) {
     int ifile;
     u_int testVal;
 
-    ifile = open(filename, O_RDWR);
+    ifile = open(filename, O_RDONLY);
     RETURN_ON_ERR(ifile < 0, "ERROR: cant open file image %s\n", filename);
 
     // test if firmware download is locked


### PR DESCRIPTION
Trying to open the firmware file with `O_RDWR` on a read-only filesystem fails immediately. It works well with `O_RDONLY`.

CC @markusj 