### PR TITLE
Added XT25F04B flash

### DIFF
--- a/upd72020x-load.c
+++ b/upd72020x-load.c
@@ -83,6 +83,7 @@ u_int lookup_rompar(const u_int rominfo) {
             return 0x760;
         case 0x005e2013: // T25S40, undocumented but working in 0x700 mode
         case 0x00856013: // P25Q40H, undocumented but working in 0x700 mode
+        case 0x000B4013: // XT25F04B, undocumented but working in 0x700 mode
         case 0x019D20FF: // Pm25LD512C
         case 0x019D207F: // Pm25LD512C2
         case 0x001F6500: // AT25F512B


### PR DESCRIPTION
This adds support XT25 - like SPI Flash with ID **0B4013**, which is used on [Axagon PCEU-43RS PCIE CONTROLLER 4X SUPERSPEED USB](https://www.axagon.eu/en/produkty/pceu-43rs). ~~For some reason, my board came with only 136 bytes flashed in the SPI flash (when comparing with the latest firmware, it is almost identical, only few bytes are modified, so I guess it is just some header describing the device). Because of this, after suspend, card did not worked. Also, for some reason, latest kernel is unable to flash the firmware, so it was full mess.~~ (explained in next comment)